### PR TITLE
Refactor tab navigation and add KeepAliveWrapper

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -10,9 +10,13 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="83f1ba98-ac45-48c6-90e8-73adca6f18e6" name="Changes" comment="">
+      <change afterPath="$PROJECT_DIR$/lib/widgets/keep_alive_wrapper.dart" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/aceup_clean.iml" beforeDir="false" afterPath="$PROJECT_DIR$/aceup_clean.iml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/lib/widgets/form_field.dart" beforeDir="false" afterPath="$PROJECT_DIR$/lib/widgets/form_field.dart" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/lib/viewmodels/today/today_viewmodel.dart" beforeDir="false" afterPath="$PROJECT_DIR$/lib/viewmodels/today/today_viewmodel.dart" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/lib/views/assignments/assignments_screen.dart" beforeDir="false" afterPath="$PROJECT_DIR$/lib/views/assignments/assignments_screen.dart" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/lib/views/shared/shared_screen.dart" beforeDir="false" afterPath="$PROJECT_DIR$/lib/views/shared/shared_screen.dart" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/lib/views/today/today_screen.dart" beforeDir="false" afterPath="$PROJECT_DIR$/lib/views/today/today_screen.dart" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/lib/widgets/content_switcher.dart" beforeDir="false" afterPath="$PROJECT_DIR$/lib/widgets/content_switcher.dart" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -103,26 +107,26 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent"><![CDATA[{
-  "keyToString": {
-    "Flutter.main.dart.executor": "Run",
-    "RunOnceActivity.ShowReadmeOnStart": "true",
-    "RunOnceActivity.cidr.known.project.marker": "true",
-    "RunOnceActivity.git.unshallow": "true",
-    "RunOnceActivity.readMode.enableVisualFormatting": "true",
-    "cf.first.check.clang-format": "false",
-    "cidr.known.project.marker": "true",
-    "dart.analysis.tool.window.visible": "false",
-    "git-widget-placeholder": "UI/fixes-and-widgets",
-    "io.flutter.reload.alreadyRun": "true",
-    "last_opened_file_path": "C:/Users/LAURA/AceUp-Flutter/assets/icons",
-    "project.structure.last.edited": "SDKs",
-    "project.structure.proportion": "0.15",
-    "project.structure.side.proportion": "0.2",
-    "settings.editor.selected.configurable": "dart.settings",
-    "show.migrate.to.gradle.popup": "false"
+  <component name="PropertiesComponent">{
+  &quot;keyToString&quot;: {
+    &quot;Flutter.main.dart.executor&quot;: &quot;Run&quot;,
+    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.git.unshallow&quot;: &quot;true&quot;,
+    &quot;RunOnceActivity.readMode.enableVisualFormatting&quot;: &quot;true&quot;,
+    &quot;cf.first.check.clang-format&quot;: &quot;false&quot;,
+    &quot;cidr.known.project.marker&quot;: &quot;true&quot;,
+    &quot;dart.analysis.tool.window.visible&quot;: &quot;false&quot;,
+    &quot;git-widget-placeholder&quot;: &quot;develop&quot;,
+    &quot;io.flutter.reload.alreadyRun&quot;: &quot;true&quot;,
+    &quot;last_opened_file_path&quot;: &quot;C:/Users/LAURA/AceUp-Flutter/assets/icons&quot;,
+    &quot;project.structure.last.edited&quot;: &quot;SDKs&quot;,
+    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
+    &quot;project.structure.side.proportion&quot;: &quot;0.2&quot;,
+    &quot;settings.editor.selected.configurable&quot;: &quot;dart.settings&quot;,
+    &quot;show.migrate.to.gradle.popup&quot;: &quot;false&quot;
   }
-}]]></component>
+}</component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
       <recent name="C:\Users\LAURA\AceUp-Flutter\assets\icons" />

--- a/lib/views/shared/shared_screen.dart
+++ b/lib/views/shared/shared_screen.dart
@@ -10,7 +10,6 @@ import '../../widgets/top_bar.dart';
 import '../../services/auth/auth_service.dart';
 import '../../widgets/floating_action_button.dart';
 
-// Wrapper para proveer el ViewModel (sin cambios)
 class SharedScreenWrapper extends StatelessWidget {
   const SharedScreenWrapper({super.key});
 
@@ -35,14 +34,11 @@ class _SharedScreenState extends State<SharedScreen> {
   @override
   void initState() {
     super.initState();
-    // Usamos addPostFrameCallback para asegurarnos de que el contexto esté disponible
-    // y para no llamar a setState o notificar a listeners durante un build.
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _loadInitialData();
     });
   }
 
-  // Nueva función para iniciar la carga de datos con el UID del usuario actual
   void _loadInitialData() {
     final authService = context.read<AuthService>();
     final userId = authService.currentUser?.uid;
@@ -50,7 +46,6 @@ class _SharedScreenState extends State<SharedScreen> {
       context.read<SharedViewModel>().fetchGroups(userId);
     } else {
       print("Error: No user is currently logged in to fetch groups.");
-      // Opcional: mostrar un SnackBar o manejar el error
     }
   }
 
@@ -62,11 +57,7 @@ class _SharedScreenState extends State<SharedScreen> {
 
     return Scaffold(
       drawer: const BurgerMenu(),
-      appBar: TopBar(
-        title: "Shared",
-        leftControlType: LeftControlType.menu,
-        rightControlType: RightControlType.none,
-      ),
+      appBar: TopBar(title: "Shared"),
       body: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
@@ -102,7 +93,6 @@ class _SharedScreenState extends State<SharedScreen> {
     );
   }
 
-  // Se pasa el contexto para el SnackBar y el ViewModel
   Widget _buildGroupList(BuildContext context, ColorScheme colors, SharedViewModel viewModel) {
     if (viewModel.state == ViewState.loading) {
       return const Center(child: CircularProgressIndicator());

--- a/lib/widgets/content_switcher.dart
+++ b/lib/widgets/content_switcher.dart
@@ -1,17 +1,14 @@
 import 'package:flutter/material.dart';
-
 import '../themes/app_typography.dart';
 
 class ContentSwitcher extends StatelessWidget {
+  final TabController controller;
   final List<String> tabs;
-  final int selectedIndex;
-  final ValueChanged<int> onTabSelected;
 
   const ContentSwitcher({
     super.key,
+    required this.controller,
     required this.tabs,
-    required this.selectedIndex,
-    required this.onTabSelected,
   });
 
   @override
@@ -24,55 +21,31 @@ class ContentSwitcher extends StatelessWidget {
 
     final double screenWidth = MediaQuery.of(context).size.width;
     final double switcherWidth = screenWidth - outerPadding.horizontal;
-    final double tabWidth = (switcherWidth - innerPadding.horizontal) / tabs.length;
 
     return Container(
-      margin:outerPadding,
-      padding: const EdgeInsets.all(4),
+      margin: outerPadding,
+      padding: innerPadding,
       width: switcherWidth,
+      height: 48,
       decoration: BoxDecoration(
         color: colors.surfaceDim,
         borderRadius: BorderRadius.circular(16),
-      ), 
-      child: Row(
-        spacing: 0.0,
-        children: List.generate(tabs.length, (index) {
-          final isSelected = index == selectedIndex;
-          return _buildTab(
-            context,
-            colors,
-            title: tabs[index],
-            isSelected: isSelected,
-            onTap: () => onTabSelected(index),
-            fixedWidth: tabWidth,
-          );
-        }),
       ),
-    );
-  }
-
-  Widget _buildTab(BuildContext context, ColorScheme colors, {
-    required String title,
-    required bool isSelected,
-    required VoidCallback onTap,
-    required double fixedWidth,
-  }) {
-    return GestureDetector(
-      onTap: onTap,
-      child: Container(
-        width: fixedWidth,
-        alignment: Alignment.center,
-        padding: const EdgeInsets.symmetric(vertical: 8),
-        decoration: BoxDecoration(
-          color: isSelected ? colors.primary : Colors.transparent,
+      child: TabBar(
+        controller: controller,
+        indicator: BoxDecoration(
+          color: colors.primary,
           borderRadius: BorderRadius.circular(12),
         ),
-        child: Text(
-          title,
-          style: isSelected
-              ? AppTypography.h5.copyWith(color: colors.onPrimary)
-              : AppTypography.h5.copyWith(color: colors.inversePrimary),
-        ),
+        indicatorSize: TabBarIndicatorSize.tab,
+        dividerColor: Colors.transparent,
+        labelColor: colors.onPrimary,
+        unselectedLabelColor: colors.inversePrimary,
+        labelStyle: AppTypography.h5,
+        unselectedLabelStyle: AppTypography.h5,
+        splashFactory: NoSplash.splashFactory,
+        overlayColor: WidgetStateProperty.all(Colors.transparent),
+        tabs: tabs.map((label) => Tab(text: label)).toList(),
       ),
     );
   }

--- a/lib/widgets/keep_alive_wrapper.dart
+++ b/lib/widgets/keep_alive_wrapper.dart
@@ -1,0 +1,25 @@
+import 'package:flutter/material.dart';
+
+class KeepAliveWrapper extends StatefulWidget {
+  final Widget child;
+
+  const KeepAliveWrapper({
+    super.key,
+    required this.child,
+  });
+
+  @override
+  State<KeepAliveWrapper> createState() => _KeepAliveWrapperState();
+}
+
+class _KeepAliveWrapperState extends State<KeepAliveWrapper>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    return widget.child;
+  }
+}


### PR DESCRIPTION
Replaces custom tab logic with TabController and TabBarView in TodayScreen and AssignmentsScreen for improved navigation and state management. Removes the 'Exams' tab from TodayViewModel and updates related logic. Adds KeepAliveWrapper widget to preserve tab state. Updates ContentSwitcher to use TabController. Cleans up unused code and improves error handling and UI consistency.