### PR TITLE
Offline Auth (Biometrics + Email/Password PBKDF2) + Auto Cache of User Settings (MVVM) — aligns with storage_memory

### DIFF
--- a/lib/services/auth/auth_service.dart
+++ b/lib/services/auth/auth_service.dart
@@ -14,6 +14,27 @@ class AuthService {
   Stream<User?> get authStateChanges => _auth.authStateChanges();
   User? get currentUser => _auth.currentUser;
   bool get isEmailVerified => _auth.currentUser?.emailVerified ?? false;
+    // ---- Sesión offline (para eventual connectivity) ----
+  static String? _offlineUserId;
+  static String? _offlineEmail;
+
+  /// uid efectivo: Firebase si existe, o sesión offline
+  String? get currentUserId => _auth.currentUser?.uid ?? _offlineUserId;
+
+  /// email efectivo: Firebase si existe, o sesión offline
+  String? get currentUserEmail => _auth.currentUser?.email ?? _offlineEmail;
+
+  /// Activa sesión local/offline (sin usuario Firebase)
+  void startOfflineSession({required String uid, required String email}) {
+    _offlineUserId = uid;
+    _offlineEmail = email;
+  }
+
+  /// Limpia sesión offline (llamar en signOut)
+  void clearOfflineSession() {
+    _offlineUserId = null;
+    _offlineEmail = null;
+  }
 
   // ---------- SIGN UP (email/clave) ----------
   Future<UserCredential> signUpEmailPassword({

--- a/lib/services/auth/offline_auth_service.dart
+++ b/lib/services/auth/offline_auth_service.dart
@@ -1,0 +1,114 @@
+// lib/services/auth/offline_auth_service.dart
+import 'dart:convert';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'password_hasher.dart';
+
+/// Administra el "desbloqueo offline" **solo** tras un primer login ONLINE exitoso.
+/// - Guarda en SecureStorage: uid, email, salt+hash PBKDF2 de la clave, enabledAt.
+/// - Permite desbloquear offline por biometría (si hay sesión habilitada) o por email+clave.
+/// - Permite cachear "user settings" en SharedPreferences (JSON), como en storage_memory (clave->valor/JSON).
+class OfflineAuthService {
+  static const _kOfflineEnabled = 'offline_enabled';
+  static const _kOfflineUID = 'offline_uid';
+  static const _kOfflineEmail = 'offline_email';
+  static const _kOfflineSalt = 'offline_salt';
+  static const _kOfflineHash = 'offline_hash';
+  static const _kOfflineEnabledAt = 'offline_enabled_at';
+  static const _kOfflineTTLDays = 90; // TTL suave; ajustable
+
+  static const _secure = FlutterSecureStorage(
+    aOptions: AndroidOptions(encryptedSharedPreferences: true),
+    iOptions: IOSOptions(accessibility: KeychainAccessibility.first_unlock),
+  );
+
+  /// Habilita el modo offline para {email, password} del usuario {uid}.
+  static Future<void> enableOfflineForCredentials({
+    required String email,
+    required String password,
+    required String uid,
+  }) async {
+    final verifier = PasswordHasher.createVerifier(password);
+    await _secure.write(key: _kOfflineEnabled, value: '1');
+    await _secure.write(key: _kOfflineUID, value: uid);
+    await _secure.write(key: _kOfflineEmail, value: email);
+    await _secure.write(key: _kOfflineSalt, value: verifier.salt);
+    await _secure.write(key: _kOfflineHash, value: verifier.hash);
+    await _secure.write(key: _kOfflineEnabledAt, value: DateTime.now().toIso8601String());
+  }
+
+  static Future<void> disableOffline() async {
+    await _secure.delete(key: _kOfflineEnabled);
+    await _secure.delete(key: _kOfflineUID);
+    await _secure.delete(key: _kOfflineEmail);
+    await _secure.delete(key: _kOfflineSalt);
+    await _secure.delete(key: _kOfflineHash);
+    await _secure.delete(key: _kOfflineEnabledAt);
+  }
+
+  static Future<bool> isOfflineEnabled() async =>
+      (await _secure.read(key: _kOfflineEnabled)) == '1';
+
+  static Future<String?> offlineUid() => _secure.read(key: _kOfflineUID);
+  static Future<String?> offlineEmail() => _secure.read(key: _kOfflineEmail);
+
+  /// Desbloqueo con email+clave cuando no hay red.
+  static Future<bool> tryOfflinePassword({
+    required String email,
+    required String password,
+  }) async {
+    final enabled = await isOfflineEnabled();
+    if (!enabled) return false;
+
+    final savedEmail = await _secure.read(key: _kOfflineEmail);
+    if (savedEmail == null || savedEmail.toLowerCase() != email.toLowerCase()) return false;
+
+    final salt = await _secure.read(key: _kOfflineSalt);
+    final hash = await _secure.read(key: _kOfflineHash);
+    if (salt == null || hash == null) return false;
+
+    final ok = PasswordHasher.verify(password, salt, hash);
+    if (!ok) return false;
+
+    final enabledAtStr = await _secure.read(key: _kOfflineEnabledAt);
+    if (enabledAtStr != null) {
+      try {
+        final enabledAt = DateTime.parse(enabledAtStr);
+        if (DateTime.now().difference(enabledAt).inDays > _kOfflineTTLDays) {
+          return false;
+        }
+      } catch (_) {}
+    }
+    return true;
+  }
+
+  /// Desbloqueo por biometría: solo valida que el modo offline esté habilitado y haya uid/email.
+  static Future<bool> tryOfflineBiometric() async {
+    final enabled = await isOfflineEnabled();
+    if (!enabled) return false;
+    final uid = await _secure.read(key: _kOfflineUID);
+    final email = await _secure.read(key: _kOfflineEmail);
+    return uid != null && email != null;
+  }
+
+  /// Info mínima de sesión offline (para AuthService.startOfflineSession)
+  static Future<({String? uid, String? email})> offlineSessionInfo() async {
+    return (uid: await offlineUid(), email: await offlineEmail());
+  }
+
+  /// Guarda user settings (JSON) en SharedPreferences bajo `settings:<uid>`.
+  static Future<void> cacheUserSettings({
+    required String uid,
+    required Map<String, dynamic> settings,
+  }) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('settings:$uid', jsonEncode(settings));
+  }
+
+  static Future<Map<String, dynamic>?> readUserSettings(String uid) async {
+    final prefs = await SharedPreferences.getInstance();
+    final str = prefs.getString('settings:$uid');
+    if (str == null) return null;
+    try { return jsonDecode(str) as Map<String, dynamic>; } catch (_) { return null; }
+  }
+}

--- a/lib/services/auth/password_hasher.dart
+++ b/lib/services/auth/password_hasher.dart
@@ -1,0 +1,70 @@
+// lib/services/auth/password_hasher.dart
+import 'dart:convert';
+import 'dart:math';
+import 'package:crypto/crypto.dart';
+
+class PasswordHasher {
+  static const int _saltLen = 16;
+  static const int _iterations = 100000;
+
+  static String genSalt() {
+    final rnd = Random.secure();
+    final bytes = List<int>.generate(_saltLen, (_) => rnd.nextInt(256));
+    return base64Url.encode(bytes);
+  }
+
+  /// PBKDF2-HMAC-SHA256 (1 bloque, dkLen<=32) con _iterations (100k).
+  static String pbkdf2(String password, String saltBase64,
+      {int iterations = _iterations, int dkLen = 32}) {
+    final salt = base64Url.decode(saltBase64);
+
+    List<int> _prf(List<int> key, List<int> data) {
+      final hmacSha256 = Hmac(sha256, key);
+      return hmacSha256.convert(data).bytes;
+    }
+
+    List<int> xorBytes(List<int> a, List<int> b) {
+      final out = List<int>.from(a);
+      for (var i = 0; i < out.length; i++) {
+        out[i] ^= b[i];
+      }
+      return out;
+    }
+
+    final blockIndex = [0, 0, 0, 1]; // INT(1) big-endian
+    final dk = List<int>.filled(dkLen, 0);
+
+    final key = utf8.encode(password);
+    final u1 = _prf(key, [...salt, ...blockIndex]);
+    var t = List<int>.from(u1);
+    var uPrev = u1;
+    for (var c = 2; c <= iterations; c++) {
+      uPrev = _prf(key, uPrev);
+      t = xorBytes(t, uPrev);
+    }
+    for (var i = 0; i < dkLen; i++) {
+      dk[i] = t[i];
+    }
+    return base64Url.encode(dk);
+  }
+
+  static ({String salt, String hash}) createVerifier(String password) {
+    final salt = genSalt();
+    final hash = pbkdf2(password, salt);
+    return (salt: salt, hash: hash);
+  }
+
+  static bool verify(String password, String salt, String expectedHash) {
+    final h = pbkdf2(password, salt);
+    return constantTimeEquals(expectedHash, h);
+  }
+
+  static bool constantTimeEquals(String a, String b) {
+    if (a.length != b.length) return false;
+    var res = 0;
+    for (var i = 0; i < a.length; i++) {
+      res |= a.codeUnitAt(i) ^ b.codeUnitAt(i);
+    }
+    return res == 0;
+  }
+}

--- a/lib/viewmodels/auth/login_viewmodel.dart
+++ b/lib/viewmodels/auth/login_viewmodel.dart
@@ -4,6 +4,7 @@ import '../../models/auth_model.dart';
 import '../../services/auth/auth_service.dart';
 import '../../services/auth/biometric_service.dart';
 import '../../services/auth/secure_store.dart';
+import '../../services/auth/offline_auth_service.dart';
 
 // ignore_for_file: type_test_with_undefined_name
 
@@ -50,45 +51,82 @@ class LoginViewModel extends Observable {
 
   // ==== Acciones ====
   Future<AuthResult> login() async {
-    final e1 = LoginForm.validateEmail(_form.email);
-    final e2 = LoginForm.validatePassword(_form.password);
-    if (e1 != null || e2 != null) {
-      final msg = e1 ?? e2 ?? 'Fix the errors';
-      _error = msg;
-      notify();
-      return AuthResult.fail(msg);
+  final e1 = LoginForm.validateEmail(_form.email);
+  final e2 = LoginForm.validatePassword(_form.password);
+  if (e1 != null || e2 != null) {
+    final msg = e1 ?? e2 ?? 'Fix the errors';
+    _error = msg;
+    notify();
+    return AuthResult.fail(msg);
+  }
+
+  _loading = true;
+  _error = null;
+  notify();
+
+  try {
+    // ONLINE primero
+    await _auth.signInEmailPassword(
+      email: _form.email,
+      password: _form.password,
+    );
+    await _auth.reloadUser();
+
+    if (!_auth.isEmailVerified) {
+      await _auth.signOut();
+      return const AuthResult(
+        ok: false,
+        message: 'Please verify your email to continue',
+        needsEmailVerification: true,
+      );
     }
 
-    _loading = true;
-    _error = null;
-    notify();
-
-    try {
-      await _auth.signInEmailPassword(
+    // === Opt-in automático: habilitar offline + cachear settings ===
+    final uid = _auth.currentUser?.uid;
+    if (uid != null) {
+      await OfflineAuthService.enableOfflineForCredentials(
         email: _form.email,
         password: _form.password,
+        uid: uid,
       );
-      await _auth.reloadUser();
 
-      if (!_auth.isEmailVerified) {
-        await _auth.signOut();
-        return const AuthResult(
-          ok: false,
-          message: 'Please verify your email to continue',
-          needsEmailVerification: true,
-        );
-      }
-      return AuthResult.success();
-    } catch (e) {
-      final msg = _friendlyAuthMessage(e);
-      _error = msg;
-      notify();
-      return AuthResult.fail(msg);
-    } finally {
-      _loading = false;
-      notify();
+      // puedes ajustar estos defaults; son livianos y seguros
+      await OfflineAuthService.cacheUserSettings(
+        uid: uid,
+        settings: {
+          "theme": "system",
+          "notifications": true,
+          "favoriteGroups": <String>[],
+        },
+      );
     }
+
+    return AuthResult.success();
+  } catch (e) {
+    // Fallback OFFLINE por red caída: email + password (PBKDF2 local)
+    final ok = await OfflineAuthService.tryOfflinePassword(
+      email: _form.email,
+      password: _form.password,
+    );
+    if (ok) {
+      final info = await OfflineAuthService.offlineSessionInfo();
+      if (info.uid != null && info.email != null) {
+        _auth.startOfflineSession(uid: info.uid!, email: info.email!);
+        return const AuthResult(ok: true, message: 'Signed in offline');
+        }
+    }
+
+    final msg = _friendlyAuthMessage(e);
+    _error = msg;
+    notify();
+    return AuthResult.fail(msg);
+  } finally {
+    _loading = false;
+    notify();
   }
+}
+
+
 
   Future<AuthResult> forgotPassword(String email) async {
     final err = LoginForm.validateEmail(email);
@@ -104,48 +142,79 @@ class LoginViewModel extends Observable {
   Future<void> resendVerificationEmail() => _auth.sendEmailVerification();
 
   Future<AuthResult> loginWithBiometrics() async {
-    final supported = await _bio.canUseBiometrics();
-    if (!supported) {
-      return AuthResult.fail('Biometrics not supported/enrolled');
-    }
-    final ok = await _bio.authenticate();
-    if (!ok) return AuthResult.fail('Biometric cancelled / failed');
+  final supported = await _bio.canUseBiometrics();
+  if (!supported) return AuthResult.fail('Biometrics not supported/enrolled');
 
-    final creds = await SecureStore.biometricCredentials();
-    final email = creds.email;
-    final pass = creds.password;
-    if (email == null || pass == null) {
-      return AuthResult.fail(
-        'No saved credentials. Sign in once with email & password.',
+  final okBio = await _bio.authenticate();
+  if (!okBio) return AuthResult.fail('Biometric cancelled / failed');
+
+  final creds = await SecureStore.biometricCredentials();
+  final email = creds.email;
+  final pass  = creds.password;
+  if (email == null || pass == null) {
+    return AuthResult.fail('No saved credentials. Sign in once with email & password.');
+  }
+
+  _loading = true;
+  _error = null;
+  notify();
+
+  try {
+    // ONLINE primero
+    await _auth.signInEmailPassword(email: email, password: pass);
+    await _auth.reloadUser();
+
+    if (!_auth.isEmailVerified) {
+      await _auth.signOut();
+      return const AuthResult(
+        ok: false,
+        message: 'Please verify your email to continue',
+        needsEmailVerification: true,
       );
     }
 
-    _loading = true;
-    _error = null;
-    notify();
+    // === Opt-in automático: habilitar offline + cachear settings ===
+    final uid = _auth.currentUser?.uid;
+    if (uid != null) {
+      await OfflineAuthService.enableOfflineForCredentials(
+        email: email,
+        password: pass,
+        uid: uid,
+      );
 
-    try {
-      await _auth.signInEmailPassword(email: email, password: pass);
-      await _auth.reloadUser();
-      if (!_auth.isEmailVerified) {
-        await _auth.signOut();
-        return const AuthResult(
-          ok: false,
-          message: 'Please verify your email to continue',
-          needsEmailVerification: true,
-        );
-      }
-      return AuthResult.success();
-    } catch (e) {
-      final msg = _friendlyAuthMessage(e);
-      _error = msg;
-      notify();
-      return AuthResult.fail(msg);
-    } finally {
-      _loading = false;
-      notify();
+      await OfflineAuthService.cacheUserSettings(
+        uid: uid,
+        settings: {
+          "theme": "system",
+          "notifications": true,
+          "favoriteGroups": <String>[],
+        },
+      );
     }
+
+    return AuthResult.success();
+  } catch (e) {
+    // Fallback OFFLINE por red caída: biometría + sesión local habilitada
+    final can = await OfflineAuthService.tryOfflineBiometric();
+    if (can) {
+      final info = await OfflineAuthService.offlineSessionInfo();
+      if (info.uid != null && info.email != null) {
+        _auth.startOfflineSession(uid: info.uid!, email: info.email!);
+        return const AuthResult(ok: true, message: 'Signed in offline');
+      }
+    }
+
+    final msg = _friendlyAuthMessage(e);
+    _error = msg;
+    notify();
+    return AuthResult.fail(msg);
+  } finally {
+    _loading = false;
+    notify();
   }
+}
+
+
 
   Future<String?> debugBiometricSummary() => _bio.debugSummary();
 
@@ -201,4 +270,38 @@ class LoginViewModel extends Observable {
     final s = error.toString();
     return s.replaceFirst('Exception: ', '');
   }
+    /// Llamar tras un login ONLINE exitoso, si el usuario acepta el prompt.
+  Future<void> enableOfflineWithCurrentCredentials() async {
+    final uid = _auth.currentUser?.uid;
+    final email = _form.email;
+    final password = _form.password;
+    if (uid != null && email.isNotEmpty && password.isNotEmpty) {
+      await OfflineAuthService.enableOfflineForCredentials(
+        email: email,
+        password: password,
+        uid: uid,
+      );
+    }
+  }
+
+  /// Guarda user settings en SharedPreferences (JSON) para mejor UX offline.
+  Future<void> cacheUserSettingsOffline(Map<String, dynamic> settings) async {
+    final uid = _auth.currentUserId;
+    if (uid == null) return;
+    await OfflineAuthService.cacheUserSettings(uid: uid, settings: settings);
+  }
+    /// Limpia toda la huella de sesión offline (SecureStorage + estado en AuthService).
+  Future<void> clearOfflineSession() async {
+    _auth.clearOfflineSession();                 // borra uid/email offline en AuthService
+    await OfflineAuthService.disableOffline();   // borra claves/salt/hash/flags en SecureStorage
+    notify();                                    // por si alguna UI muestra estado de sesión
+  }
+
+  /// Cierra sesión completa respetando MVVM (online + offline).
+  Future<void> signOutAll() async {
+    await _auth.signOut();       // tu signOut normal (Firebase)
+    await clearOfflineSession(); // y luego limpieza offline
+  }
+
+
 }

--- a/lib/views/auth/login_screen.dart
+++ b/lib/views/auth/login_screen.dart
@@ -1,4 +1,4 @@
-import 'package:flutter/material.dart';
+// lib/views/auth/login_screen.dart
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
@@ -9,7 +9,6 @@ import '../../themes/app_typography.dart';
 import '../../viewmodels/auth/login_viewmodel.dart';
 
 import '../../services/auth/secure_store.dart';
-
 import '../../services/startup_ttfp.dart';
 
 import '../../models/auth_model.dart';
@@ -222,17 +221,23 @@ class _LoginScreenState extends State<LoginScreen> {
       ..setPassword(password);
 
     final res = await widget.vm.login();
+
     if (!mounted) return;
 
     if (!res.ok) {
       if (res.needsEmailVerification) {
         await _showVerifyDialog();
       }
-      _showSnack(res.message ?? 'Wrong email or password.');
+      _showSnack(res.message ?? 'Login failed');
       return;
     }
 
-    // Post-login: biometría
+    // NOTA: El ViewModel ya habilita automáticamente:
+    // - Modo offline (PBKDF2) para este email/clave/uid
+    // - Cache de user settings en SharedPreferences
+    // Aquí solo gestionamos la biometría como UX extra.
+
+    // Post-login: biometría (opcional, con prompts propios)
     final check = await widget.vm.biometricPostLoginCheck(email);
     if (check.supported) {
       if (!check.enabled) {

--- a/lib/views/auth/logout_screen.dart
+++ b/lib/views/auth/logout_screen.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../viewmodels/auth/login_viewmodel.dart';
+import '../../services/auth/offline_auth_service.dart';
+import 'package:provider/provider.dart';
+import '../../viewmodels/auth/login_viewmodel.dart';
 
 class LogoutScreen extends StatelessWidget {
   final LoginViewModel vm;
@@ -16,10 +19,12 @@ class LogoutScreen extends StatelessWidget {
           children: [
             FilledButton.tonal(
               onPressed: () async {
-                await vm.signOut();
+                final vm = context.read<LoginViewModel>();     // obtenemos el VM
+                await vm.signOutAll();                         // MVVM: logout total
                 if (!context.mounted) return;
-                Navigator.pushNamedAndRemoveUntil(context, '/', (r) => false);
-              },
+                Navigator.pushNamedAndRemoveUntil(context, '/login', (_) => false);
+              }
+              ,
               child: const Text('Cerrar sesión'),
             ),
           ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -290,7 +290,7 @@ packages:
     source: hosted
     version: "3.1.2"
   crypto:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: crypto
       sha256: "1e445881f28f22d6140f181e07737b22f1e099a5e1ff94b0af2f9e4a463f4855"
@@ -724,26 +724,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -1177,10 +1177,10 @@ packages:
     dependency: transitive
     description:
       name: sqflite_android
-      sha256: ecd684501ebc2ae9a83536e8b15731642b9570dc8623e0073d227d0ee2bfea88
+      sha256: "2b3070c5fa881839f8b402ee4a39c1b4d561704d4ebbbcfb808a119bc2a1701b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2+2"
+    version: "2.4.1"
   sqflite_common:
     dependency: transitive
     description:
@@ -1305,10 +1305,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.4"
   timing:
     dependency: transitive
     description:
@@ -1425,10 +1425,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
@@ -1510,5 +1510,5 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
+  dart: ">=3.8.1 <4.0.0"
   flutter: ">=3.29.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,6 +46,8 @@ dependencies:
   supabase_flutter: ^2.10.2
   package_info_plus: ^8.3.1
   firebase_analytics: ^12.0.3
+  crypto: ^3.0.3
+  shared_preferences: ^2.2.2
   
   # Local Storage - SQLite
   drift: ^2.14.0
@@ -62,9 +64,7 @@ dependencies:
   
   # Image caching
   cached_network_image: ^3.3.0
-  
-  # Preferences
-  shared_preferences: ^2.2.2
+
   
   # Connectivity detection
   connectivity_plus: ^6.0.5


### PR DESCRIPTION
- Implements eventual connectivity for Auth only.

- After the first successful online sign-in, the app stores a salted PBKDF2-HMAC-SHA256 password verifier (no plaintext) with uid/email in SecureStorage to enable offline unlock.

- Offline biometrics: when the network is unavailable, biometric auth starts a local session and navigates to Today.

- Offline email+password: local PBKDF2 verification against the stored verifier (TTL ~90 days) → local session → Today (AppSpecific).

- Auto opt-in: removed prompts; enabling offline login and caching user settings now happens automatically after a successful online sign-in.

- User settings are cached in SharedPreferences (local/private) to improve offline UX.

- MVVM-only: views don’t call services directly for logout; LoginViewModel.signOutAll() performs Firebase sign-out + offline cleanup.

How it aligns with storage_memory

SecureStorage → sensitive material & password verifier (salt + PBKDF2).

SharedPreferences → lightweight user settings (local/private).

Local DB (Drift) → unchanged (domain data).
This mirrors the storage_memory layering and responsibilities.

Security notes

No plaintext passwords stored.

PBKDF2-HMAC-SHA256 with a random salt (100k iterations).

Offline access bounded by TTL (~90 days) and is revoked on logout or online password change.