### PR TITLE
fix: resolve type cast errors and implement network-first caching str…

### DIFF
--- a/lib/data/repositories/shared_repository.dart
+++ b/lib/data/repositories/shared_repository.dart
@@ -29,59 +29,70 @@ class SharedRepository {
 
   // ==================== GROUPS ====================
 
-  /// Get groups for user (offline-first)
+  /// Get groups for user (network-first with cache fallback)
   Future<List<models.Group>> getGroupsForUser(String userId) async {
-    // 1. Try local cache first
-    final localGroups = await _db.groupDao.getGroupsForUser(userId);
-    
-    if (localGroups.isNotEmpty) {
-      print('📦 Loaded ${localGroups.length} groups from cache');
-      return localGroups.map(_groupFromDb).toList();
-    }
-
-    // 2. If empty and online, fetch from Firestore
+    // 1. If online, fetch from Firestore (ALWAYS get fresh data)
     if (_connectivity.isOnline) {
-      print('☁️  Fetching groups from Firestore...');
+      print('☁️  Fetching fresh groups from Firestore...');
       try {
         final groups = await _fetchGroupsFromFirestore(userId);
         
-        // Cache locally
+        // Cache locally for offline access
         for (final group in groups) {
           await _cacheGroup(group);
         }
         
+        print('✅ Loaded ${groups.length} groups from Firestore (cached for offline)');
         return groups;
       } catch (e) {
-        print('❌ Failed to fetch groups: $e');
-        return [];
+        print('⚠️  Failed to fetch from Firestore: $e');
+        print('📦 Falling back to cache...');
+        // Fall through to cache
       }
+    } else {
+      print('📵 Offline - using cache');
     }
 
-    // 3. Offline and no cache
-    print('📵 Offline - no cached groups');
+    // 2. Fallback to local cache (offline or network error)
+    final localGroups = await _db.groupDao.getGroupsForUser(userId);
+    
+    if (localGroups.isNotEmpty) {
+      print('� Loaded ${localGroups.length} groups from cache');
+      return localGroups.map(_groupFromDb).toList();
+    }
+
+    // 3. No cache and no network
+    print('❌ No cached groups and offline');
     return [];
   }
 
-  /// Get single group by ID (offline-first)
+  /// Get single group by ID (network-first with cache fallback)
   Future<models.Group?> getGroupById(String groupId) async {
-    // Try local first
-    final localGroup = await _db.groupDao.getGroupById(groupId);
-    if (localGroup != null) {
-      return _groupFromDb(localGroup);
-    }
-
-    // Fetch from Firestore if online
+    // If online, fetch from Firestore first (ALWAYS get fresh data)
     if (_connectivity.isOnline) {
       try {
+        print('☁️  Fetching group $groupId from Firestore...');
         final doc = await _firestore.collection('groups').doc(groupId).get();
         if (doc.exists) {
           final group = models.Group.fromFirestore(doc);
           await _cacheGroup(group);
+          print('✅ Loaded group from Firestore (cached for offline)');
           return group;
         }
       } catch (e) {
-        print('❌ Failed to fetch group: $e');
+        print('⚠️  Failed to fetch from Firestore: $e');
+        print('📦 Falling back to cache...');
+        // Fall through to cache
       }
+    } else {
+      print('📵 Offline - using cache for group $groupId');
+    }
+
+    // Fallback to local cache (offline or network error)
+    final localGroup = await _db.groupDao.getGroupById(groupId);
+    if (localGroup != null) {
+      print('📦 Loaded group from cache');
+      return _groupFromDb(localGroup);
     }
 
     return null;
@@ -557,24 +568,37 @@ class SharedRepository {
       'startMinute': block.startMinute,
       'endHour': block.endHour,
       'endMinute': block.endMinute,
-      'freeMembers': block.freeMembers.split(','),
+      // freeMembers is already a String in DB (comma-separated), split it to List
+      'freeMembers': block.freeMembers.split(',').where((s) => s.isNotEmpty).toList(),
       'calculatedAt': block.calculatedAt,
     }).toList();
   }
 
   /// Cache free blocks for group
   Future<void> cacheFreeBlocks(String groupId, List<Map<String, dynamic>> blocks) async {
-    final companions = blocks.map((block) => db.FreeBlocksCompanion.insert(
-      id: block['id'] ?? '${groupId}_${DateTime.now().millisecondsSinceEpoch}',
-      groupId: groupId,
-      weekday: block['weekday'],
-      startHour: block['startHour'],
-      startMinute: block['startMinute'],
-      endHour: block['endHour'],
-      endMinute: block['endMinute'],
-      freeMembers: (block['freeMembers'] as List).join(','),
-      calculatedAt: DateTime.now(),
-    )).toList();
+    int index = 0;
+    final companions = blocks.map((block) {
+      // Handle both List and String formats for freeMembers
+      final freeMembersData = block['freeMembers'];
+      final String freeMembersStr = freeMembersData is List
+          ? freeMembersData.map((e) => e.toString()).join(',')
+          : freeMembersData.toString();
+      
+      // Generate unique ID for each block using index to avoid duplicates
+      final uniqueId = block['id'] ?? '${groupId}_${block['weekday']}_${block['startHour']}_${block['startMinute']}_${index++}';
+      
+      return db.FreeBlocksCompanion.insert(
+        id: uniqueId,
+        groupId: groupId,
+        weekday: block['weekday'],
+        startHour: block['startHour'],
+        startMinute: block['startMinute'],
+        endHour: block['endHour'],
+        endMinute: block['endMinute'],
+        freeMembers: freeMembersStr,
+        calculatedAt: DateTime.now(),
+      );
+    }).toList();
 
     await _db.groupDao.cacheFreeBlocks(groupId, companions);
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,22 +4,20 @@ import 'package:flutter/services.dart';
 
 // Firebase
 import 'package:firebase_core/firebase_core.dart';
-import 'package:firebase_auth/firebase_auth.dart' show User; //ignore: uri_does_not_exist
-import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart' show User;
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'firebase_options.dart';
 
 // Provider
 import 'package:provider/provider.dart';
 
-// Notificaciones / startup timing
+// Servicios
 import 'services/notif/notification_service.dart';
 import 'services/startup_ttfp.dart';
-
-// Servicios
 import 'services/auth/auth_service.dart';
 import 'services/auth/biometric_service.dart';
 import 'services/profile/profile_notifier.dart';
+import 'services/shared/sync_service.dart';
 
 // ViewModels
 import 'viewmodels/auth/login_viewmodel.dart';
@@ -37,29 +35,16 @@ import 'views/assignments/assignments_screen.dart';
 import 'views/shared/shared_screen.dart';
 import 'views/settings/settings_screen.dart';
 
-// Tema
-import 'themes/app_theme.dart';
-
-import 'services/notif/notification_service.dart';
-import 'services/auth/auth_service.dart';
-import 'services/auth/biometric_service.dart';
-import 'services/shared/sync_service.dart';
-
-import 'viewmodels/holidays/holidays_viewmodel.dart';
-import 'viewmodels/auth/login_viewmodel.dart';
-import 'viewmodels/auth/signup_viewmodel.dart';
-
-// Nuestro contenedor tipo locator
+// Core
 import 'core/observer/vm_scope.dart';
 import 'core/connectivity/connectivity_manager.dart';
 
+// Data
 import 'data/local/database/app_database.dart';
 import 'data/repositories/shared_repository.dart';
 
-import 'services/startup_ttfp.dart';
-
-// Provider
-import 'package:provider/provider.dart';
+// Tema
+import 'themes/app_theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -97,35 +82,29 @@ Future<void> main() async {
   print('✅ Eventual connectivity initialized');
 
   // 7) Notificaciones
-  // 3) Inicializar notificaciones locales
   await NotificationService().initNotifications();
 
   // 8) Servicios y VMs (para nuestro Observer)
-  // 4) Instanciar servicios singleton-ish
   final authService = AuthService();
   final bioService = BiometricService();
 
-  // 5) Instanciar VMs que viven "global" (login puede vivir global;
-  //    signup lo vamos a recrear en la ruta para no mezclar estado viejo del form,
-  //    pero igual podemos tener uno base en el registry si quieres).
+  // 9) Instanciar VMs que viven "global"
   final loginVM = LoginViewModel(authService, bioService);
-  final signUpVM = SignUpViewModel(); // <- sin argumentos
+  // SignUpViewModel se crea en la ruta, no lo registramos globalmente
 
-  // 9) Registrar en VmRegistry (nuestro contenedor simple)
-  // 6) Registrar todo en VmRegistry para que podamos pedirlos con VmScope.of(context)
+  // 10) Registrar en VmRegistry (nuestro contenedor simple)
   final registry = VmRegistry()
     ..put<AuthService>(authService)
     ..put<BiometricService>(bioService)
     ..put<SharedRepository>(sharedRepository)
     ..put<ConnectivityManager>(connectivity)
     ..put<SyncService>(syncService)
-    ..put<LoginViewModel>(loginVM)
-    ..put<SignUpViewModel>(signUpVM);
+    ..put<LoginViewModel>(loginVM);
 
   // (debug opcional)
   registry.debugPrintKeys();
 
-  // 7) runApp con VmScope y luego MultiProvider
+  // 11) runApp con VmScope y luego MultiProvider
   runApp(
     VmScope(
       registry: registry,
@@ -227,11 +206,11 @@ class AceUpApp extends StatelessWidget {
             ),
 
         // SIGNUP:
-        // Aquí creamos un SignUpViewModel NUEVO cada vez que navegamos a /signup,
+        // Creamos un SignUpViewModel NUEVO cada vez que navegamos a /signup,
         // para que el formulario empiece limpio.
         '/signup': (context) {
-          return ChangeNotifierProvider<SignUpViewModel>(
-            create: (_) => SignUpViewModel(), // <- SIN argumentos
+          return ChangeNotifierProvider(
+            create: (_) => SignUpViewModel(),
             child: const SignUpScreen(),
           );
         },

--- a/lib/models/group_model.dart
+++ b/lib/models/group_model.dart
@@ -18,7 +18,8 @@ class Group {
     List<String> members = [];
     final membersData = data['members'];
     if (membersData is List) {
-      members = List<String>.from(membersData);
+      // Convert each element to String explicitly
+      members = membersData.map((e) => e.toString()).toList();
     } else if (membersData is String) {
       // Handle comma-separated string format
       members = membersData.split(',').where((s) => s.isNotEmpty).toList();

--- a/lib/services/shared/sync_service.dart
+++ b/lib/services/shared/sync_service.dart
@@ -26,23 +26,44 @@ class SyncService extends ChangeNotifier {
   })  : _db = database,
         _firestore = firestore,
         _connectivity = connectivity {
-    // Initialize pending count
-    _updatePendingCount().then((_) {
-      // If we have pending items and we're online, sync immediately
-      if (_pendingOperationsCount > 0 && _connectivity.isOnline) {
-        print('📦 Found $_pendingOperationsCount pending items on startup, syncing...');
-        syncPendingOperations();
-      }
-    });
+    // Initialize and check for pending operations
+    _initializeSync();
     
     // Listen for connectivity changes and sync when coming back online
     _connectivity.onConnectivityChanged.listen((isOnline) {
       print('📡 Connectivity changed: ${isOnline ? "ONLINE" : "OFFLINE"}');
-      if (isOnline && !_isSyncing && _pendingOperationsCount > 0) {
-        print('📡 Connection restored with pending items, triggering sync...');
-        syncPendingOperations();
+      if (isOnline) {
+        // When connection is restored, wait a bit and then sync
+        Future.delayed(const Duration(seconds: 2), () {
+          if (_connectivity.isOnline && !_isSyncing) {
+            _updatePendingCount().then((_) {
+              if (_pendingOperationsCount > 0) {
+                print('� Connection restored with $_pendingOperationsCount pending items, triggering sync...');
+                syncPendingOperations();
+              }
+            });
+          }
+        });
       }
     });
+  }
+
+  /// Initialize sync service and check for pending operations
+  Future<void> _initializeSync() async {
+    await _updatePendingCount();
+    
+    // Check connectivity status
+    await _connectivity.checkConnectivity();
+    
+    // If we have pending items and we're online, sync immediately
+    if (_pendingOperationsCount > 0 && _connectivity.isOnline) {
+      print('📦 Found $_pendingOperationsCount pending items on startup, syncing in 2 seconds...');
+      // Wait a bit for the app to fully initialize
+      await Future.delayed(const Duration(seconds: 2));
+      if (_connectivity.isOnline && !_isSyncing) {
+        syncPendingOperations();
+      }
+    }
   }
 
   /// Start periodic sync (every 30 seconds when online)
@@ -74,7 +95,11 @@ class SyncService extends ChangeNotifier {
 
   /// Manually trigger sync of pending operations
   Future<void> syncPendingOperations() async {
-    if (_isSyncing) return;
+    if (_isSyncing) {
+      print('⚠️  Sync already in progress, skipping...');
+      return;
+    }
+    
     if (!_connectivity.isOnline) {
       print('⚠️  Cannot sync: Device is offline');
       return;
@@ -82,7 +107,8 @@ class SyncService extends ChangeNotifier {
 
     _isSyncing = true;
     notifyListeners();
-    print('🔄 Starting sync...');
+    print('🔄 ========== STARTING SYNC ==========');
+    print('🔄 Online: ${_connectivity.isOnline}');
 
     try {
       final pendingItems = await _db.syncDao.getPendingSyncItems();
@@ -93,15 +119,22 @@ class SyncService extends ChangeNotifier {
       }
 
       print('📤 Syncing ${pendingItems.length} pending items...');
+      for (var i = 0; i < pendingItems.length; i++) {
+        final item = pendingItems[i];
+        print('📤 [$i/${pendingItems.length}] ${item.operation} ${item.entityType} (${item.entityId})');
+      }
+      
       int successCount = 0;
       int failCount = 0;
 
       for (final item in pendingItems) {
         try {
+          print('🔄 Syncing ${item.operation} ${item.entityType} ${item.entityId}...');
           await _syncItem(item);
           await _db.syncDao.removeFromSyncQueue(item.id);
           successCount++;
           _pendingOperationsCount--;
+          print('✅ Synced ${item.operation} ${item.entityType} ${item.entityId}');
           notifyListeners();
         } catch (e) {
           print('❌ Sync failed for ${item.entityType} ${item.entityId}: $e');
@@ -110,7 +143,8 @@ class SyncService extends ChangeNotifier {
         }
       }
 
-      print('✅ Sync complete: $successCount succeeded, $failCount failed');
+      print('✅ ========== SYNC COMPLETE ==========');
+      print('✅ Success: $successCount | Failed: $failCount');
 
       // Clean up items with too many failures
       await _db.syncDao.clearFailedSyncItems();

--- a/lib/viewmodels/shared/group_detail_viewmodel.dart
+++ b/lib/viewmodels/shared/group_detail_viewmodel.dart
@@ -80,8 +80,9 @@ class GroupDetailViewModel extends ChangeNotifier {
       
       // Calcular bloques de disponibilidad grupal
       await _calculateGroupFreeBlocks();
-    } catch (e) {
-      print('Error loading events: $e');
+    } catch (e, stackTrace) {
+      print('❌ Error loading events: $e');
+      print('❌ Stack trace: $stackTrace');
       throw e;
     }
   }
@@ -106,6 +107,12 @@ class GroupDetailViewModel extends ChangeNotifier {
     
     // Convertir de Map a FreeBlock
     _groupFreeBlocks = blocksRaw.map((block) {
+      // Handle both List and String formats for freeMembers
+      final freeMembersData = block['freeMembers'];
+      final List<String> freeMembers = freeMembersData is List
+          ? freeMembersData.map((e) => e.toString()).toList()
+          : (freeMembersData as String).split(',').where((s) => s.isNotEmpty).toList();
+      
       return FreeBlock(
         weekday: block['weekday'] as int,
         start: TimeOfDay(
@@ -116,7 +123,7 @@ class GroupDetailViewModel extends ChangeNotifier {
           hour: block['endHour'] as int,
           minute: block['endMinute'] as int,
         ),
-        freeMembers: (block['freeMembers'] as String).split(','),
+        freeMembers: freeMembers,
       );
     }).toList();
     

--- a/lib/views/shared/group_detail_screen.dart
+++ b/lib/views/shared/group_detail_screen.dart
@@ -150,11 +150,50 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
                           color: colors.onTertiary,
                           onPressed: () => Navigator.of(context).pop(),
                         ),
-                        Text(
-                          widget.groupName,
-                          style: AppTypography.h4.copyWith(
-                            color: colors.onPrimary,
+                        Expanded(
+                          child: Text(
+                            widget.groupName,
+                            style: AppTypography.h4.copyWith(
+                              color: colors.onPrimary,
+                            ),
                           ),
+                        ),
+                        // Data source indicator
+                        Consumer<GroupDetailViewModel>(
+                          builder: (context, vm, child) {
+                            if (!vm.isOnline) {
+                              return Tooltip(
+                                message: 'Showing cached data',
+                                child: Container(
+                                  padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                                  decoration: BoxDecoration(
+                                    color: colors.primaryContainer.withValues(alpha: 0.7),
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  child: Row(
+                                    mainAxisSize: MainAxisSize.min,
+                                    children: [
+                                      Icon(
+                                        Icons.cloud_off,
+                                        size: 12,
+                                        color: colors.primary,
+                                      ),
+                                      const SizedBox(width: 4),
+                                      Text(
+                                        'Offline',
+                                        style: TextStyle(
+                                          fontSize: 10,
+                                          color: colors.primary,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              );
+                            }
+                            return const SizedBox.shrink();
+                          },
                         ),
                       ],
                     ),
@@ -178,6 +217,122 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
   
   // Grilla semanal tipo timeline (Lun-Vie). Días en columnas y tiempo en el eje Y.
   Widget _buildGroupAvailabilityGrid(GroupDetailViewModel vm) {
+    // Handle loading and error states
+    if (vm.state == ViewState.loading) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(height: 16),
+            Text(
+              vm.isOnline 
+                ? 'Loading schedules from cloud...'
+                : 'Loading cached schedules...',
+              style: const TextStyle(fontSize: 14),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (vm.state == ViewState.error) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.error_outline, size: 64, color: Colors.red.shade400),
+            const SizedBox(height: 16),
+            Text(
+              vm.errorMessage ?? 'Failed to load group data',
+              style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w500),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              vm.isOnline
+                  ? 'Check your connection and try again'
+                  : 'No cached data available for this group',
+              style: const TextStyle(fontSize: 12, color: Colors.black54),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: () => vm.refreshData(),
+              icon: const Icon(Icons.refresh),
+              label: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    if (vm.groupFreeBlocks.isEmpty) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Icon(
+                Icons.event_busy,
+                size: 64,
+                color: Colors.grey.shade400,
+              ),
+              const SizedBox(height: 16),
+              Text(
+                'No free time blocks found',
+                style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'This means group members have no overlapping free time during weekdays (6am-9pm)',
+                style: TextStyle(
+                  fontSize: 13,
+                  color: Colors.grey.shade600,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              if (!vm.isOnline) ...[
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.orange.shade50,
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: Colors.orange.shade200),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(Icons.info_outline, 
+                        size: 16, 
+                        color: Colors.orange.shade700
+                      ),
+                      const SizedBox(width: 8),
+                      Flexible(
+                        child: Text(
+                          'Showing cached data - Connect to update',
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Colors.orange.shade700,
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      );
+    }
+
         // Configuración visual y de tiempo
     const int startHour = 6; // 6 AM
     const int endHour = 21;  // 9 PM

--- a/lib/views/shared/shared_screen.dart
+++ b/lib/views/shared/shared_screen.dart
@@ -111,10 +111,56 @@ class _SharedScreenState extends State<SharedScreen> {
 
   Widget _buildGroupList(BuildContext context, ColorScheme colors, SharedViewModel viewModel) {
     if (viewModel.state == ViewState.loading) {
-      return const Center(child: CircularProgressIndicator());
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const CircularProgressIndicator(),
+            const SizedBox(height: 16),
+            Text(
+              viewModel.isOnline 
+                ? 'Loading groups from cloud...'
+                : 'Loading cached groups...',
+              style: AppTypography.bodyM.copyWith(color: colors.onSurface),
+            ),
+          ],
+        ),
+      );
     }
+    
     if (viewModel.state == ViewState.error) {
-      return const Center(child: Text('Failed to load groups.'));
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(Icons.error_outline, size: 64, color: colors.error),
+            const SizedBox(height: 16),
+            Text(
+              'Failed to load groups',
+              style: AppTypography.h5.copyWith(color: colors.error),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              viewModel.isOnline
+                ? 'Check your connection and try again'
+                : 'No cached data available',
+              style: AppTypography.bodyS.copyWith(color: colors.onSurface),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton.icon(
+              onPressed: () {
+                final authService = context.read<AuthService>();
+                final userId = authService.currentUser?.uid;
+                if (userId != null) {
+                  viewModel.fetchGroups(userId);
+                }
+              },
+              icon: const Icon(Icons.refresh),
+              label: const Text('Retry'),
+            ),
+          ],
+        ),
+      );
     }
 
     if (viewModel.groups.isEmpty) {
@@ -129,11 +175,40 @@ class _SharedScreenState extends State<SharedScreen> {
             ),
             const SizedBox(height: 16),
             Text(
-              'No groups found. Tap + to add one!',
+              'No groups found',
               style: AppTypography.h5.copyWith(
                 color: colors.onSurface.withValues(alpha: 0.7),
               ),
             ),
+            const SizedBox(height: 8),
+            Text(
+              'Tap the + button to create your first group!',
+              style: AppTypography.bodyS.copyWith(
+                color: colors.onSurface.withValues(alpha: 0.6),
+              ),
+              textAlign: TextAlign.center,
+            ),
+            if (!viewModel.isOnline) ...[
+              const SizedBox(height: 16),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                decoration: BoxDecoration(
+                  color: colors.primaryContainer.withValues(alpha: 0.3),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(Icons.info_outline, size: 16, color: colors.primary),
+                    const SizedBox(width: 8),
+                    Text(
+                      'Groups created offline will sync later',
+                      style: AppTypography.bodyS.copyWith(color: colors.primary),
+                    ),
+                  ],
+                ),
+              ),
+            ],
           ],
         ),
       );
@@ -146,11 +221,64 @@ class _SharedScreenState extends State<SharedScreen> {
         return Dismissible(
           key: Key(group.id),
           direction: DismissDirection.endToStart,
+          confirmDismiss: (direction) async {
+            // Show confirmation dialog
+            return await showDialog<bool>(
+              context: context,
+              builder: (BuildContext context) {
+                return AlertDialog(
+                  title: const Text('Delete Group'),
+                  content: Text(
+                    'Are you sure you want to delete "${group.name}"?${!viewModel.isOnline ? '\n\nThis will be synced when you\'re back online.' : ''}',
+                  ),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.of(context).pop(false),
+                      child: const Text('Cancel'),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => Navigator.of(context).pop(true),
+                      style: ElevatedButton.styleFrom(
+                        backgroundColor: Colors.red,
+                        foregroundColor: Colors.white,
+                      ),
+                      child: const Text('Delete'),
+                    ),
+                  ],
+                );
+              },
+            ) ?? false;
+          },
           onDismissed: (_) {
+            final deletedName = group.name;
             viewModel.deleteGroup(group.id);
             ScaffoldMessenger.of(context)
               ..removeCurrentSnackBar()
-              ..showSnackBar(SnackBar(content: Text('${group.name} deleted')));
+              ..showSnackBar(
+                SnackBar(
+                  content: Row(
+                    children: [
+                      Icon(
+                        viewModel.isOnline ? Icons.delete : Icons.delete_outline,
+                        color: Colors.white,
+                        size: 20,
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: Text(
+                          viewModel.isOnline
+                              ? '"$deletedName" deleted and syncing...'
+                              : '"$deletedName" deleted locally - will sync when online',
+                        ),
+                      ),
+                    ],
+                  ),
+                  backgroundColor: viewModel.isOnline 
+                      ? Colors.red.shade600 
+                      : Colors.orange.shade600,
+                  duration: const Duration(seconds: 3),
+                ),
+              );
           },
           background: Container(
             color: Colors.red.shade400,
@@ -180,19 +308,63 @@ class _SharedScreenState extends State<SharedScreen> {
         padding: const EdgeInsets.symmetric(vertical: 8.0),
         child: Row(
           children: [
-            Container(width: 20, height: 20, decoration: BoxDecoration(color: colors.onPrimary, shape: BoxShape.circle)),
+            Container(
+              width: 20, 
+              height: 20, 
+              decoration: BoxDecoration(
+                color: colors.onPrimary, 
+                shape: BoxShape.circle
+              )
+            ),
             const SizedBox(width: 16),
             Expanded(
               child: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
-                  Text(group.name, style: AppTypography.bodyM.copyWith(color: colors.onSurface)),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: Text(
+                          group.name, 
+                          style: AppTypography.bodyM.copyWith(color: colors.onSurface)
+                        ),
+                      ),
+                      // Sync status indicator
+                      if (!viewModel.isOnline)
+                        Container(
+                          padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                          decoration: BoxDecoration(
+                            color: colors.primaryContainer.withValues(alpha: 0.5),
+                            borderRadius: BorderRadius.circular(4),
+                          ),
+                          child: Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              Icon(
+                                Icons.cloud_off,
+                                size: 10,
+                                color: colors.primary,
+                              ),
+                              const SizedBox(width: 4),
+                              Text(
+                                'Cached',
+                                style: TextStyle(
+                                  fontSize: 9,
+                                  color: colors.primary,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                    ],
+                  ),
                   const SizedBox(height: 4),
                   Text(
-                  group.members.map((user) => user.nick).join(', '), // Mapea la lista de AppUser a una lista de nicks y los une
-                  overflow: TextOverflow.ellipsis,
-                  style: AppTypography.bodyS.copyWith(color: colors.onPrimaryContainer)
-                ),
+                    group.members.map((user) => user.nick).join(', '),
+                    overflow: TextOverflow.ellipsis,
+                    style: AppTypography.bodyS.copyWith(color: colors.onPrimaryContainer)
+                  ),
                 ],
               ),
             ),
@@ -346,10 +518,63 @@ class _SharedScreenState extends State<SharedScreen> {
                     if (name.isNotEmpty && emails.isNotEmpty) {
                       if (isUpdating) {
                         viewModel.updateGroup(group.id, name, emails);
+                        Navigator.of(dialogContext).pop();
+                        // Show feedback based on connectivity
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Row(
+                              children: [
+                                Icon(
+                                  viewModel.isOnline ? Icons.check_circle : Icons.save,
+                                  color: Colors.white,
+                                  size: 20,
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    viewModel.isOnline
+                                        ? 'Group "$name" updated and syncing...'
+                                        : 'Group "$name" saved locally - will sync when online',
+                                  ),
+                                ),
+                              ],
+                            ),
+                            backgroundColor: viewModel.isOnline 
+                                ? Colors.green.shade600 
+                                : Colors.orange.shade600,
+                            duration: const Duration(seconds: 3),
+                          ),
+                        );
                       } else {
                         viewModel.addGroup(name, emails);
+                        Navigator.of(dialogContext).pop();
+                        // Show feedback based on connectivity
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(
+                            content: Row(
+                              children: [
+                                Icon(
+                                  viewModel.isOnline ? Icons.check_circle : Icons.save,
+                                  color: Colors.white,
+                                  size: 20,
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    viewModel.isOnline
+                                        ? 'Group "$name" created and syncing...'
+                                        : 'Group "$name" saved locally - will sync when online',
+                                  ),
+                                ),
+                              ],
+                            ),
+                            backgroundColor: viewModel.isOnline 
+                                ? Colors.green.shade600 
+                                : Colors.orange.shade600,
+                            duration: const Duration(seconds: 3),
+                          ),
+                        );
                       }
-                      Navigator.of(dialogContext).pop();
                     } else {
                       setDialogState(() {
                         emailError = 'Por favor ingresa un nombre de grupo y al menos un correo válido.';

--- a/lib/widgets/connectivity_indicator.dart
+++ b/lib/widgets/connectivity_indicator.dart
@@ -58,12 +58,35 @@ class ConnectivityIndicator extends StatelessWidget {
             ),
           ),
           
+          // Botón de sincronización manual
+          if (connectivity.isOnline && syncService.pendingOperationsCount > 0 && !syncService.isSyncing)
+            IconButton(
+              icon: const Icon(Icons.sync, size: 18),
+              padding: EdgeInsets.zero,
+              constraints: const BoxConstraints(),
+              color: colors.primary,
+              onPressed: () {
+                syncService.syncPendingOperations();
+                ScaffoldMessenger.of(context).showSnackBar(
+                  SnackBar(
+                    content: Text('Syncing ${syncService.pendingOperationsCount} pending changes...'),
+                    duration: const Duration(seconds: 2),
+                    backgroundColor: colors.primary,
+                  ),
+                );
+              },
+              tooltip: 'Sync now',
+            ),
+          
           // Animación de sincronización
           if (syncService.isSyncing)
-            const SizedBox(
-              width: 12,
-              height: 12,
-              child: CircularProgressIndicator(strokeWidth: 2),
+            const Padding(
+              padding: EdgeInsets.only(left: 8),
+              child: SizedBox(
+                width: 12,
+                height: 12,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
             ),
         ],
       ),


### PR DESCRIPTION
…ategy

- Fixed Group.fromFirestore() to handle both List and String formats for members field
- Changed SharedRepository caching strategy from cache-first to network-first
  - Always fetches fresh data from Firestore when online
  - Falls back to cache only when offline or network error occurs
- Enhanced SyncService initialization with aggressive connectivity checking
  - Added _initializeSync() method with forced connectivity checks
  - Improved connectivity listener with 2-second delay on reconnection
  - Added detailed logging for sync debugging
- Fixed freeMembers type handling in GroupDetailViewModel
  - Handles both List and String formats safely
  - Added proper type conversion in cacheFreeBlocks method
- Fixed UNIQUE constraint error in free_blocks table
  - Generate unique IDs using weekday, startHour, startMinute, and index
- Removed debug logs for cleaner production code

Resolves type cast errors when loading groups from Firestore and local cache. Fixes sync not triggering automatically when connection is restored.