### PR TITLE
feat: Add manual refresh from Firebase for free blocks testing

### DIFF
--- a/lib/data/repositories/shared_repository.dart
+++ b/lib/data/repositories/shared_repository.dart
@@ -767,6 +767,33 @@ class SharedRepository {
     print('🗑️  Invalidated free blocks cache for group $groupId (LRU ✅ + SQLite ✅) ${_freeBlocksCache.stats}');
   }
 
+  /// Invalidate events cache for a group (force refresh from Firebase)
+  /// 
+  /// **When to call:**
+  /// - Testing schedule changes from Firebase Console
+  /// - Member updates their schedule in Firebase
+  /// - Manual refresh requested by user
+  /// 
+  /// **What it does:**
+  /// - Deletes all cached ClassTemplate, Subjects, and Terms for group members
+  /// - Forces fresh fetch from Firebase on next getEventsForGroup()
+  /// 
+  /// This ensures you see the latest schedule data from Firebase.
+  Future<void> invalidateEventsCache(String groupId) async {
+    print('🗑️  Invalidating events cache for group $groupId...');
+    
+    // Get all group members
+    final members = await getGroupMembers(groupId);
+    
+    // Delete cached schedules for each member
+    for (final member in members) {
+      await _db.memberScheduleDao.clearUserSchedule(member.uid);
+      print('   ✅ Cleared cache for ${member.nick} (${member.uid})');
+    }
+    
+    print('🗑️  Events cache invalidated for group $groupId - ${members.length} members cleared');
+  }
+
   /// Clear all free blocks cache (useful for logout or data reset)
   Future<void> clearAllFreeBlocksCache() async {
     _freeBlocksCache.clear();

--- a/lib/viewmodels/shared/group_detail_viewmodel.dart
+++ b/lib/viewmodels/shared/group_detail_viewmodel.dart
@@ -87,6 +87,35 @@ class GroupDetailViewModel extends ChangeNotifier {
     }
   }
 
+  /// Forzar refresh desde Firebase (ignorar cache local)
+  /// Útil cuando sabes que los datos cambiaron en Firebase
+  Future<void> forceRefreshFromFirebase() async {
+    if (!_isOnline) {
+      _errorMessage = 'No hay conexión a internet';
+      _setState(ViewState.error);
+      return;
+    }
+
+    _setState(ViewState.loading);
+    try {
+      print('🔄 Forzando refresh desde Firebase...');
+      
+      // 1. Invalidar cache de eventos
+      await _repository.invalidateEventsCache(groupId);
+      
+      // 2. Invalidar cache de FreeBlocks
+      await _repository.invalidateFreeBlocksCache(groupId);
+      
+      // 3. Recargar todo desde Firebase
+      await _loadGroupData();
+      
+      print('✅ Datos actualizados desde Firebase');
+    } catch (e) {
+      _errorMessage = e.toString();
+      _setState(ViewState.error);
+    }
+  }
+
   Future<void> _calculateGroupFreeBlocks() async {
     // Agrupar eventos por miembro
     final memberEvents = <String, List<CalendarEvent>>{};

--- a/lib/views/shared/group_detail_screen.dart
+++ b/lib/views/shared/group_detail_screen.dart
@@ -103,14 +103,27 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
     final colors = theme.colorScheme;
+    final vm = context.watch<GroupDetailViewModel>();
 
     return Scaffold(
       drawer: const BurgerMenu(),
       appBar: TopBar(
         title: "Shared",
         leftControlType: LeftControlType.menu,
-        rightControlType: RightControlType.none,
-        onRightPressed: () {},
+        rightControlType: RightControlType.refresh,
+        onRightPressed: () async {
+          // Forzar refresh desde Firebase (limpiar cache y recargar)
+          await vm.forceRefreshFromFirebase();
+          // Mostrar snackbar de confirmación
+          if (context.mounted) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(
+                content: Text('🔄 Datos actualizados desde Firebase'),
+                duration: Duration(seconds: 2),
+              ),
+            );
+          }
+        },
       ),
       body: Column(
         children: [

--- a/lib/widgets/top_bar.dart
+++ b/lib/widgets/top_bar.dart
@@ -3,7 +3,7 @@ import '../themes/app_typography.dart';
 import '../themes/app_icons.dart';
 
 enum LeftControlType { back, menu, cancel }
-enum RightControlType { edit, none, save }
+enum RightControlType { edit, none, save, refresh }
 
 class TopBar extends StatelessWidget implements PreferredSizeWidget {
   final String title;
@@ -84,6 +84,11 @@ class TopBar extends StatelessWidget implements PreferredSizeWidget {
         return TextButton(
           onPressed: onRightPressed,
           child: Text("Save", style: AppTypography.actionM.copyWith(color: colors.onSecondary)),
+        );
+      case RightControlType.refresh:
+        return IconButton(
+          icon: Icon(Icons.refresh),
+          onPressed: onRightPressed,
         );
       case RightControlType.none:
         return null;


### PR DESCRIPTION
- Add invalidateEventsCache() method in SharedRepository to clear cached schedules
- Add forceRefreshFromFirebase() in GroupDetailViewModel to invalidate both events and free blocks caches
- Add refresh button (RightControlType.refresh) to TopBar widget
- Implement refresh functionality in GroupDetailScreen with user feedback snackbar

This allows developers to test schedule changes from Firebase Console in real-time by manually refreshing cached data, solving the offline-first cache blocking updates during development/testing.